### PR TITLE
Fix directory for install in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /home/user
 
 RUN git clone --recurse-submodules https://github.com/FertigLab/pycogaps-gpn.git
 
-WORKDIR ./pycogaps/
+WORKDIR ./pycogaps-gpn/
 RUN git pull
 
 RUN pip install -r requirements.txt --user


### PR DESCRIPTION
Just a fix for the directory as the Dockerfile pulled pycogaps-gpn but then tries to cd into just './pycogaps' which is not there